### PR TITLE
Fix swoosh content attachment

### DIFF
--- a/lib/resend/emails/attachment.ex
+++ b/lib/resend/emails/attachment.ex
@@ -11,7 +11,7 @@ defmodule Resend.Emails.Attachment do
     :content,
     :content_type,
     :filename,
-    :path
+    path: ""
   ]
 
   @impl true

--- a/lib/resend/swoosh/adapter.ex
+++ b/lib/resend/swoosh/adapter.ex
@@ -69,10 +69,9 @@ defmodule Resend.Swoosh.Adapter do
 
   defp format_attachment(%Swoosh.Attachment{} = attachment) do
     %Resend.Emails.Attachment{
-      content: attachment.data,
+      content: Swoosh.Attachment.get_content(attachment, :base64),
       content_type: attachment.content_type,
-      filename: attachment.filename,
-      path: attachment.path
+      filename: attachment.filename
     }
   end
 


### PR DESCRIPTION
Use the Swoosh [`get_content/2`](https://github.com/swoosh/swoosh/blob/v1.16.10/lib/swoosh/adapters/postmark.ex#L222-L224C60) function to read the attachment file. This was based on the official implementations:

- [`Mailtrap`](https://github.com/swoosh/swoosh/blob/v1.16.10/lib/swoosh/adapters/mailtrap.ex#L174-L176C60) implementation
- [`Postmark`](https://github.com/swoosh/swoosh/blob/v1.16.10/lib/swoosh/adapters/postmark.ex#L222-L224C60) implementation


This fix: https://github.com/elixir-saas/resend-elixir/pull/2#issuecomment-2292401543 

---

@epd, @jtormey 