### PR TITLE
Allow opts to funs of Resend.Emails

### DIFF
--- a/lib/resend/client.ex
+++ b/lib/resend/client.ex
@@ -40,12 +40,7 @@ defmodule Resend.Client do
   def get(client, castable_module, path, opts \\ []) do
     client_module = client.client || Resend.Client.TeslaClient
 
-    opts =
-      opts
-      |> Keyword.put(:method, :get)
-      |> Keyword.put(:url, path)
-
-    client_module.request(client, opts)
+    client_module.request(client, method: :get, url: path, opts: opts)
     |> handle_response(path, castable_module)
   end
 
@@ -55,13 +50,7 @@ defmodule Resend.Client do
   def post(client, castable_module, path, body \\ %{}, opts \\ []) do
     client_module = client.client || Resend.Client.TeslaClient
 
-    opts =
-      opts
-      |> Keyword.put(:method, :post)
-      |> Keyword.put(:url, path)
-      |> Keyword.put(:body, body)
-
-    client_module.request(client, opts)
+    client_module.request(client, method: :post, url: path, body: body, opts: opts)
     |> handle_response(path, castable_module)
   end
 
@@ -71,13 +60,7 @@ defmodule Resend.Client do
   def delete(client, castable_module, path, body \\ %{}, opts \\ []) do
     client_module = client.client || Resend.Client.TeslaClient
 
-    opts =
-      opts
-      |> Keyword.put(:method, :delete)
-      |> Keyword.put(:url, path)
-      |> Keyword.put(:body, body)
-
-    client_module.request(client, opts)
+    client_module.request(client, method: :delete, url: path, body: body, opts: opts)
     |> handle_response(path, castable_module)
   end
 

--- a/lib/resend/emails.ex
+++ b/lib/resend/emails.ex
@@ -26,19 +26,25 @@ defmodule Resend.Emails do
   """
   @spec send(map()) :: Resend.Client.response(Email.t())
   @spec send(Resend.Client.t(), map()) :: Resend.Client.response(Email.t())
-  def send(client \\ Resend.client(), opts) do
-    Resend.Client.post(client, Email, "/emails", %{
-      subject: opts[:subject],
-      to: opts[:to],
-      from: opts[:from],
-      cc: opts[:cc],
-      bcc: opts[:bcc],
-      reply_to: opts[:reply_to],
-      headers: opts[:headers],
-      html: opts[:html],
-      text: opts[:text],
-      attachments: opts[:attachments]
-    })
+  def send(client \\ Resend.client(), params, opts \\ []) do
+    Resend.Client.post(
+      client,
+      Email,
+      "/emails",
+      %{
+        subject: params[:subject],
+        to: params[:to],
+        from: params[:from],
+        cc: params[:cc],
+        bcc: params[:bcc],
+        reply_to: params[:reply_to],
+        headers: params[:headers],
+        html: params[:html],
+        text: params[:text],
+        attachments: params[:attachments]
+      },
+      opts
+    )
   end
 
   @doc """
@@ -47,11 +53,7 @@ defmodule Resend.Emails do
   """
   @spec get(String.t()) :: Resend.Client.response(Email.t())
   @spec get(Resend.Client.t(), String.t()) :: Resend.Client.response(Email.t())
-  def get(client \\ Resend.client(), email_id) do
-    Resend.Client.get(client, Email, "/emails/:id",
-      opts: [
-        path_params: [id: email_id]
-      ]
-    )
+  def get(client \\ Resend.client(), email_id, opts \\ []) do
+    Resend.Client.get(client, Email, "/emails/#{email_id}", opts)
   end
 end


### PR DESCRIPTION
Previously, there was no way to pass opts to the Tesla client.
This PR fixes the issue by allowing opts to be passed to the Tesla client.

e.g.

```elixir
Resend.client(config)
|> Resend.Emails.send(params, adapter: [receive_timeout: :timer.seconds(30)])
```