### PR TITLE
fix for inline images

### DIFF
--- a/lib/resend/emails/attachment.ex
+++ b/lib/resend/emails/attachment.ex
@@ -11,6 +11,7 @@ defmodule Resend.Emails.Attachment do
     :content,
     :content_type,
     :filename,
+    :inline_content_id,
     path: ""
   ]
 
@@ -20,7 +21,8 @@ defmodule Resend.Emails.Attachment do
       content: map["content"],
       content_type: map["content_type"],
       filename: map["filename"],
-      path: map["path"]
+      path: map["path"],
+      inline_content_id: map["inline_content_id"]
     }
   end
 end

--- a/lib/resend/swoosh/adapter.ex
+++ b/lib/resend/swoosh/adapter.ex
@@ -68,11 +68,13 @@ defmodule Resend.Swoosh.Adapter do
   end
 
   defp format_attachment(%Swoosh.Attachment{} = attachment) do
+    cid = if is_nil(attachment.cid), do: attachment.filename, else: attachment.cid
+
     %Resend.Emails.Attachment{
       content: Swoosh.Attachment.get_content(attachment, :base64),
       content_type: attachment.content_type,
       filename: attachment.filename,
-      inline_content_id: attachment.filename
+      inline_content_id: cid
     }
   end
 

--- a/lib/resend/swoosh/adapter.ex
+++ b/lib/resend/swoosh/adapter.ex
@@ -71,7 +71,8 @@ defmodule Resend.Swoosh.Adapter do
     %Resend.Emails.Attachment{
       content: Swoosh.Attachment.get_content(attachment, :base64),
       content_type: attachment.content_type,
-      filename: attachment.filename
+      filename: attachment.filename,
+      inline_content_id: attachment.filename
     }
   end
 


### PR DESCRIPTION
Supports CIDs for inline images. If a custom CID is provided, it will be used, otherwise, the filename will be applied.