### PR TITLE
support for content-id and inline attachments - fixes issue #9

### DIFF
--- a/lib/resend/emails/attachment.ex
+++ b/lib/resend/emails/attachment.ex
@@ -5,12 +5,19 @@ defmodule Resend.Emails.Attachment do
   @behaviour Resend.Castable
   @derive Jason.Encoder
 
-  @type t() :: map()
+  @type t() :: %__MODULE__{
+          content: String.t() | nil,
+          content_type: String.t() | nil,
+          filename: String.t() | nil,
+          content_id: String.t() | nil,
+          path: String.t()
+        }
 
   defstruct [
     :content,
     :content_type,
     :filename,
+    :content_id,
     path: ""
   ]
 
@@ -20,6 +27,7 @@ defmodule Resend.Emails.Attachment do
       content: map["content"],
       content_type: map["content_type"],
       filename: map["filename"],
+      content_id: map["content_id"],
       path: map["path"]
     }
   end

--- a/lib/resend/swoosh/adapter.ex
+++ b/lib/resend/swoosh/adapter.ex
@@ -71,7 +71,8 @@ defmodule Resend.Swoosh.Adapter do
     %Resend.Emails.Attachment{
       content: Swoosh.Attachment.get_content(attachment, :base64),
       content_type: attachment.content_type,
-      filename: attachment.filename
+      filename: attachment.filename,
+      content_id: attachment.cid
     }
   end
 

--- a/test/resend/emails_test.exs
+++ b/test/resend/emails_test.exs
@@ -55,5 +55,97 @@ defmodule Resend.EmailsTest do
                  Resend.Emails.get(email_id)
       end
     end
+
+    test "Attachment struct accepts content_id field" do
+      attachment = %Resend.Emails.Attachment{
+        filename: "logo.jpg",
+        content: "base64data",
+        content_type: "image/jpeg",
+        content_id: "logo-image"
+      }
+
+      assert attachment.content_id == "logo-image"
+    end
+
+    test "Attachment.cast/1 includes content_id from map" do
+      map = %{
+        "filename" => "logo.jpg",
+        "content" => "base64data",
+        "content_type" => "image/jpeg",
+        "content_id" => "logo-image"
+      }
+
+      attachment = Resend.Emails.Attachment.cast(map)
+
+      assert attachment.content_id == "logo-image"
+    end
+
+    test "Jason encoding includes content_id" do
+      attachment = %Resend.Emails.Attachment{
+        filename: "logo.jpg",
+        content: "base64data",
+        content_id: "logo-image"
+      }
+
+      json = Jason.encode!(attachment)
+      decoded = Jason.decode!(json)
+
+      assert decoded["content_id"] == "logo-image"
+    end
+
+    test "Handles nil content_id gracefully" do
+      attachment = %Resend.Emails.Attachment{
+        filename: "document.pdf",
+        content: "base64data"
+        # content_id is nil
+      }
+
+      json = Jason.encode!(attachment)
+      # Should encode without errors
+      assert is_binary(json)
+
+      decoded = Jason.decode!(json)
+      # nil fields are encoded as null in JSON
+      assert decoded["content_id"] == nil
+    end
+
+    test "Sends email with inline attachment via Swoosh adapter", context do
+      # Create Swoosh email with inline attachment
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to(context.to)
+        |> Swoosh.Email.from(context.from)
+        |> Swoosh.Email.subject("Test Inline Image")
+        |> Swoosh.Email.html_body(~s|<img src="cid:test-logo">|)
+        |> Swoosh.Email.attachment(
+          Swoosh.Attachment.new(
+            {:data, "fake_binary_data"},
+            filename: "logo.jpg",
+            content_type: "image/jpeg",
+            type: :inline,
+            cid: "test-logo"
+          )
+        )
+
+      # Mock the API call and assert content_id is sent
+      Tesla.Mock.mock(fn request ->
+        assert request.method == :post
+        assert request.url == "https://api.resend.com/emails"
+
+        body = Jason.decode!(request.body)
+
+        # Assert attachment has content_id from Swoosh cid
+        assert [attachment] = body["attachments"]
+        assert attachment["content_id"] == "test-logo"
+        assert attachment["filename"] == "logo.jpg"
+        assert attachment["content_type"] == "image/jpeg"
+
+        %Tesla.Env{status: 200, body: %{"id" => context.sent_email_id}}
+      end)
+
+      # Deliver via Swoosh adapter
+      config = [api_key: context.api_key]
+      assert {:ok, _} = Resend.Swoosh.Adapter.deliver(email, config)
+    end
   end
 end


### PR DESCRIPTION
Fixes #9 

Summary:
  - Add content_id field to Resend.Emails.Attachment struct
  - Update @type specification with proper types
  - Map Swoosh cid field to Resend content_id in adapter
  - Add 5 test cases for content_id functionality
  - Enables embedding inline images via CID references