### PR TITLE
feat: support resend templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,48 @@ Resend.Emails.send(client, %{
 
 View additional documentation at <https://hexdocs.pm/resend>.
 
+## Templates
+
+Resend supports [templates](https://resend.com/docs/dashboard/templates/introduction) for sending transactional emails. You can use templates with both the direct API and the Swoosh adapter.
+
+### Using Templates with the Direct API
+
+```ex
+Resend.Emails.send(%{
+  from: "Acme <[email protected]>",
+  to: "[email protected]",
+  template: %{
+    id: "order-confirmation",
+    variables: %{
+      PRODUCT: "Vintage Macintosh",
+      PRICE: 499
+    }
+  }
+})
+```
+
+### Using Templates with Swoosh
+
+To use templates with the Swoosh adapter, use `put_provider_option/3` to add the template information:
+
+```ex
+import Swoosh.Email
+
+new()
+|> from({"Acme", "[email protected]"})
+|> to("[email protected]")
+|> put_provider_option(:template, %{
+  id: "order-confirmation",
+  variables: %{
+    PRODUCT: "Vintage Macintosh",
+    PRICE: 499
+  }
+})
+|> MyApp.Mailer.deliver()
+```
+
+When using templates, you don't need to set the `html_body` or `text_body` as the template will provide the content.
+
 ## Swoosh Adapter
 
 This library includes a Swoosh adapter to make using Resend with a new Phoenix project as easy as

--- a/lib/resend/emails.ex
+++ b/lib/resend/emails.ex
@@ -20,14 +20,29 @@ defmodule Resend.Emails do
     * `:html` - The HTML-formatted body of the email
     * `:text` - The text-formatted body of the email
     * `:attachments` - List of attachments to include in the email
+    * `:template` - Template to use for the email, a map with `:id` and `:variables` keys
 
-  You must include one or both of the `:html` and `:text` options.
+  You must include one or both of the `:html` and `:text` options, or use a `:template`.
+
+  ## Template Example
+
+      Resend.Emails.send(%{
+        from: "Acme <[email protected]>",
+        to: "[email protected]",
+        template: %{
+          id: "order-confirmation",
+          variables: %{
+            PRODUCT: "Vintage Macintosh",
+            PRICE: 499
+          }
+        }
+      })
 
   """
   @spec send(map()) :: Resend.Client.response(Email.t())
   @spec send(Resend.Client.t(), map()) :: Resend.Client.response(Email.t())
   def send(client \\ Resend.client(), opts) do
-    Resend.Client.post(client, Email, "/emails", %{
+    payload = %{
       subject: opts[:subject],
       to: opts[:to],
       from: opts[:from],
@@ -38,7 +53,16 @@ defmodule Resend.Emails do
       html: opts[:html],
       text: opts[:text],
       attachments: opts[:attachments]
-    })
+    }
+
+    payload =
+      if opts[:template] do
+        Map.put(payload, :template, opts[:template])
+      else
+        payload
+      end
+
+    Resend.Client.post(client, Email, "/emails", payload)
   end
 
   @doc """

--- a/lib/resend/emails/email.ex
+++ b/lib/resend/emails/email.ex
@@ -20,6 +20,7 @@ defmodule Resend.Emails.Email do
           text: String.t() | nil,
           html: String.t() | nil,
           attachments: list(Attachment.t()) | nil,
+          template: map() | nil,
           last_event: String.t() | nil,
           created_at: DateTime.t() | nil
         }
@@ -37,6 +38,7 @@ defmodule Resend.Emails.Email do
     :text,
     :html,
     :attachments,
+    :template,
     :last_event,
     :created_at
   ]
@@ -55,6 +57,7 @@ defmodule Resend.Emails.Email do
       text: map["text"],
       html: map["html"],
       attachments: map["attachments"],
+      template: map["template"],
       last_event: map["last_event"],
       created_at: Util.parse_iso8601(map["created_at"])
     }


### PR DESCRIPTION
# What's new?

Adding support for [Resend templates](https://resend.com/docs/dashboard/templates/introduction), i.e.:

```
curl -X POST 'https://api.resend.com/emails' \
  -H 'Authorization: Bearer re_xxxxxxxxx' \
  -H 'Content-Type: application/json' \
  -d $'{
    "from": "Acme <onboarding@resend.dev>",
    "to": "delivered@resend.dev",
    "template": {
      "id": "order-confirmation",
      "variables": {
        "PRODUCT": "Vintage Macintosh",
        "PRICE": 499
      }
    }
}'
```

# Testing

```
mix test
```

And some manual testing by:
```
$ iex -S mix
> client = Resend.client(api_key: "re_your_api_key_here")
> Resend.Emails.send(client, %{
  from: "Your Name <[email protected]>",
  subject: "test subject",
  to: "[email protected]",
  template: %{
    id: "your-template-id",
    variables: %{
      YOUR_VARIABLE_NAME: "Your Variable Value"
    }
  }
})
```